### PR TITLE
Update lore reaction handling and message posting

### DIFF
--- a/lorebot.go
+++ b/lorebot.go
@@ -26,7 +26,7 @@ func (l *Lorebot) SendMessage(msg Message) {
 	fmt.Println("Attempting to send message: " + msg.Content)
 	_, _, err := l.SlackAPI.PostMessage(msg.ChannelID, msg.Content, params)
 	if err != nil {
-		fmt.Printf("failed to post message: %v", err)
+		fmt.Printf("failed to post message: %v\n", err)
 	}
 }
 

--- a/lorebot.go
+++ b/lorebot.go
@@ -10,10 +10,9 @@ import (
 )
 
 type Lorebot struct {
-	Pg           *PostgresClient
-	SlackAPI     *slack.Client
-	LorebotID    string
-	MessageQueue chan Message
+	Pg        *PostgresClient
+	SlackAPI  *slack.Client
+	LorebotID string
 }
 
 type Message struct {
@@ -21,11 +20,13 @@ type Message struct {
 	Content   string
 }
 
-func (l *Lorebot) MessageWorker() {
+func (l *Lorebot) SendMessage(msg Message) {
 	params := slack.PostMessageParameters{Username: "Lorebot", IconEmoji: ":lore:"}
-	for msg := range l.MessageQueue {
-		fmt.Println("Attempting to send message: " + msg.Content)
-		l.SlackAPI.PostMessage(msg.ChannelID, msg.Content, params)
+
+	fmt.Println("Attempting to send message: " + msg.Content)
+	_, _, err := l.SlackAPI.PostMessage(msg.ChannelID, msg.Content, params)
+	if err != nil {
+		fmt.Printf("failed to post message: %v", err)
 	}
 }
 
@@ -60,11 +61,12 @@ func (l *Lorebot) HandleLoreReact(channelId string, timestamp string) {
 		l.Pg.UpvoteLore(message.User, message.Text)
 		return
 	}
+
 	fmt.Println("User: " + message.User + " + lore id: " + l.LorebotID)
 
 	l.Pg.InsertLore(message.User, message.Text)
 	msg := Message{ChannelID: channelId, Content: "Lore added: <@" + message.User + ">: " + message.Text}
-	l.MessageQueue <- msg
+	l.SendMessage(msg)
 	return
 }
 
@@ -81,8 +83,7 @@ func (l *Lorebot) HandleMessage(ev *slack.MessageEvent) {
 		case "help":
 			out := "Usage: @lorebot <help | random | recent | search <query> | top | user <username>>"
 			msg := Message{ChannelID: ev.Channel, Content: out}
-			fmt.Println("Trying to write message: " + out)
-			l.MessageQueue <- msg
+			l.SendMessage(msg)
 			return
 		case "random":
 			lores = l.Pg.RandomLore()
@@ -111,7 +112,7 @@ func (l *Lorebot) HandleMessage(ev *slack.MessageEvent) {
 				out += "<@" + lore.userID + ">" + ": " + lore.Message + " (" + strconv.Itoa(lore.Score) + ")" + "\n"
 			}
 			msg := Message{ChannelID: ev.Channel, Content: out}
-			l.MessageQueue <- msg
+			l.SendMessage(msg)
 		}
 	}
 }
@@ -125,7 +126,6 @@ func (l *Lorebot) HandleReaction(ev *slack.ReactionAddedEvent) {
 }
 
 func (l *Lorebot) Start() {
-	go l.MessageWorker()
 	rtm := l.SlackAPI.NewRTM()
 	go rtm.ManageConnection()
 	for msg := range rtm.IncomingEvents {
@@ -149,10 +149,9 @@ func parseUserID(unparsed string) string {
 
 func NewLorebot(conf *Configuration) *Lorebot {
 	bot := Lorebot{
-		Pg:           NewPostgresClient(conf),
-		SlackAPI:     slack.New(conf.Token),
-		LorebotID:    conf.BotID,
-		MessageQueue: make(chan Message, 1000),
+		Pg:        NewPostgresClient(conf),
+		SlackAPI:  slack.New(conf.Token),
+		LorebotID: conf.BotID,
 	}
 	bot.SlackAPI.SetDebug(true)
 

--- a/lorebot.go
+++ b/lorebot.go
@@ -50,16 +50,18 @@ func (l *Lorebot) HandleLoreReact(channelId string, timestamp string) {
 
 	message := history.Messages[0]
 
-	if l.Pg.LoreExists(message.Text, message.User) {
-		l.Pg.UpvoteLore(message.User, message.Text)
-		return
-	}
-	fmt.Println("User: " + message.User + " + lore id: " + l.LorebotID)
 	// Can't lore the lorebot
 	if message.User == "" {
 		fmt.Println("Ingoring self lore")
 		return
 	}
+
+	if l.Pg.LoreExists(message.Text, message.User) {
+		l.Pg.UpvoteLore(message.User, message.Text)
+		return
+	}
+	fmt.Println("User: " + message.User + " + lore id: " + l.LorebotID)
+
 	l.Pg.InsertLore(message.User, message.Text)
 	msg := Message{ChannelID: channelId, Content: "Lore added: <@" + message.User + ">: " + message.Text}
 	l.MessageQueue <- msg

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseUserID(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{
+			desc:     "Standard",
+			input:    "<@U123ABC>",
+			expected: "U123ABC",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.desc, func(t *testing.T) {
+			out := parseUserID(tc.input)
+
+			if out != tc.expected {
+				t.Fatalf("expected: '%v', got: '%v'", tc.expected, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Makes a few changes:

- Removes the MessageWorker and its MessageQueue, each handling goroutine will now post messages themselves
- Restricts the history query to only pull the message we're interested in
- Adds the first test, lol